### PR TITLE
Fix edgeSpatial.rect to plain Rect struct instead of pointer

### DIFF
--- a/common/graph_rtree.go
+++ b/common/graph_rtree.go
@@ -23,7 +23,7 @@ type edgeSpatial struct {
 }
 
 func (e *edgeSpatial) Bounds() rtreego.Rect {
-    isEmpty := reflect.DeepEqual(rtreego.Rect{}, e.rect)
+	isEmpty := reflect.DeepEqual(rtreego.Rect{}, e.rect)
 	if isEmpty {
 		r := e.edge.Src.Point.Rectangle()
 		r = r.Extend(e.edge.Dst.Point)

--- a/common/graph_rtree.go
+++ b/common/graph_rtree.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dhconnelly/rtreego"
 
 	"math"
+	"reflect"
 )
 
 func RtreegoRect(r Rectangle) rtreego.Rect {
@@ -22,6 +23,12 @@ type edgeSpatial struct {
 }
 
 func (e *edgeSpatial) Bounds() rtreego.Rect {
+    isEmpty := reflect.DeepEqual(rtreego.Rect{}, e.rect)
+	if isEmpty {
+		r := e.edge.Src.Point.Rectangle()
+		r = r.Extend(e.edge.Dst.Point)
+		e.rect = RtreegoRect(r)
+	}
 	return e.rect
 }
 

--- a/common/graph_rtree.go
+++ b/common/graph_rtree.go
@@ -6,7 +6,7 @@ import (
 	"math"
 )
 
-func RtreegoRect(r Rectangle) *rtreego.Rect {
+func RtreegoRect(r Rectangle) rtreego.Rect {
 	dx := math.Max(0.00000001, r.Max.X - r.Min.X)
 	dy := math.Max(0.00000001, r.Max.Y - r.Min.Y)
 	rect, err := rtreego.NewRect(rtreego.Point{r.Min.X, r.Min.Y}, []float64{dx, dy})
@@ -18,15 +18,10 @@ func RtreegoRect(r Rectangle) *rtreego.Rect {
 
 type edgeSpatial struct {
 	edge *Edge
-	rect *rtreego.Rect
+	rect rtreego.Rect
 }
 
-func (e *edgeSpatial) Bounds() *rtreego.Rect {
-	if e.rect == nil {
-		r := e.edge.Src.Point.Rectangle()
-		r = r.Extend(e.edge.Dst.Point)
-		e.rect = RtreegoRect(r)
-	}
+func (e *edgeSpatial) Bounds() rtreego.Rect {
 	return e.rect
 }
 


### PR DESCRIPTION
This is a corresponding change to a recent commit on rtreego (2008b37524910b3e54046f1f7b12139316a0461d)